### PR TITLE
Closes #35 add timeout to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -96,15 +96,8 @@ func newClientTransport(c *clientSpec) *httptransport.Runtime {
 
 	client := &http.Client{
 		Timeout: c.timeout,
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 10 * time.Second,
-		},
+		Transport: http.DefaultTransport,
+	}
 	}
 
 	transport := httptransport.NewWithClient(c.host, c.basePath, c.schemes, client)

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package cloudgo
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -95,7 +94,7 @@ func newClientTransport(c *clientSpec) *httptransport.Runtime {
 	})
 
 	client := &http.Client{
-		Timeout: c.timeout,
+		Timeout:   c.timeout,
 		Transport: http.DefaultTransport,
 	}
 

--- a/client.go
+++ b/client.go
@@ -98,7 +98,6 @@ func newClientTransport(c *clientSpec) *httptransport.Runtime {
 		Timeout: c.timeout,
 		Transport: http.DefaultTransport,
 	}
-	}
 
 	transport := httptransport.NewWithClient(c.host, c.basePath, c.schemes, client)
 	transport.DefaultAuthentication = auther


### PR DESCRIPTION
Provide a possibility to set a customized timeout for the client.
Default settings are:
- Timeout: 30s
- KeepAlive: 30s
- TLSHandshakeTimeout: 10s
- ResponseHeaderTimeout: 10s