### PR TITLE
Pull builder before generating client.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test:
 generate-client:
 	rm -rf api
 	mkdir -p api
+	docker pull metalstack/builder
 	docker run --user $$(id -u):$$(id -g) --rm -v ${PWD}:/work metalstack/builder swagger generate client -f cloud-api.json -t api --skip-validation
 
 .PHONY: golangcicheck


### PR DESCRIPTION
Should prevent generating the client with an old builder image.