### PR TITLE
Override client default timeout when timeout is set.

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fi-ts/cloud-go/api/client"
 	"github.com/go-openapi/runtime"
+	openclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/metal-stack/security"
 
@@ -41,6 +42,11 @@ func AuthType(authType string) option {
 
 //Timeout sets the timeout for a new client
 func Timeout(timeout time.Duration) option {
+	// overriding the default timeout as otherwise all request need to be called with
+	// WithTimeout or WithContext
+	// still open issue: https://github.com/go-swagger/go-swagger/issues/2583
+	openclient.DefaultTimeout = timeout
+
 	return func(c *clientSpec) {
 		c.timeout = timeout
 	}


### PR DESCRIPTION
Without this change (even when setting `cloudgo.Timeout` to 5m):

```
❯ time c billing container --from 2022-05-01
Error: Post "https://api.fits.cloud/cloud/v1/accounting/container-usage": context deadline exceeded
cloudctl billing container --from 2022-05-01  0,05s user 0,01s system 0% cpu 30,030 total
``` 

With this change:

```
❯ time c billing container --from 2022-05-01
Error: [POST /v1/accounting/container-usage][500] containerUsage default  rpc error: code = ResourceExhausted desc = grpc: received message larger than max (81712271 vs. 64000000) (500)
cloudctl billing container --from 2022-05-01  0,04s user 0,02s system 0% cpu 57,250 total
```